### PR TITLE
Update homepage copy and reorder projects carousel

### DIFF
--- a/components/Bio.tsx
+++ b/components/Bio.tsx
@@ -18,11 +18,11 @@ export default function Bio() {
           <div className="flex-1 lg:max-w-[50rem]">
             <div className="space-y-6 text-[1.125rem] md:text-[1.25rem] lg:text-[1.5rem] font-inter text-primary-green">
               <p>
-              I make products that solve problems for musicians, music lovers, and the organizations that support them.
+              I build products that solve problems for musicians, music lovers, and the organizations that support them.
               </p>
               
               <p>
-                Currently: re-imagining music creation for the AI era at Splice, finishing a master&apos;s
+                Currently: re-imagining music creation software at Splice, finishing a master&apos;s
                 degree in machine learning at USC Viterbi.
               </p>
               

--- a/data/projects/baseball-scores.json
+++ b/data/projects/baseball-scores.json
@@ -1,9 +1,9 @@
 {
   "title": "Baseball Scores",
   "description": "Ambient soundtracks for the national pastime",
-  "year": "2025",
+  "year": "2026",
   "image": "/images/projects/baseball-scores.png",
   "tags": ["webdev", "silly-little-project"],
   "url": "https://baseballscores.io",
-  "defaultOrder": 2
+  "defaultOrder": 0
 } 


### PR DESCRIPTION
## Summary
- Change "make products" to "build products" in bio
- Update "Currently" line: "re-imagining music creation software at Splice" (removed "for the AI era")
- Bump Baseball Scores year from 2025 to 2026
- Move Baseball Scores to first position in the projects carousel

## Test plan
- [ ] Verify homepage bio text renders correctly
- [ ] Verify Baseball Scores appears first in the carousel with year 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)